### PR TITLE
Run spring completely with a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
 FROM ruby:2.3
 RUN apt-get update -qq && apt-get install -y nodejs
 
-# We need the spring socket file to be readable by the local user on the host,
-# so we need to set up a user account with the same UID. Change this if your
-# UID is not 1000. Obviously there are ways to make this more flexible (build
-# args etc).
-RUN useradd --create-home --user-group --uid 1000 app
-
-RUN mkdir /app && chown -R app:app /app
+RUN mkdir /app
 WORKDIR /app
-USER app
 
 ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,29 @@
 version: '2'
+volumes:
+  bundle_cache:
+    driver: local
 services:
   web:
     build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    environment:
+      - SPRING_TMP_PATH=tmp
+      - SPRING_SOCKET=tmp/spring.sock
+      - SPRING_PIDFILE=tmp/spring.pid
     volumes:
       - .:/app
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+      - bundle_cache:/usr/local/bundle
     ports:
       - "3000:3000"
-
+    depends_on:
+      - spring
   spring:
     build: .
+    command: bundle exec spring server
+    environment:
+      - SPRING_TMP_PATH=tmp
+      - SPRING_SOCKET=tmp/spring.sock
+      - SPRING_PIDFILE=tmp/spring.pid
     volumes:
       - .:/app
-    command: spring server
-
-    # This ensures that the pid namespace is shared between the host
-    # and the container. It's not necessary to be able to run spring
-    # commands, but it is necessary for "spring status" and "spring stop"
-    # to work properly.
-    pid: host
+      - bundle_cache:/usr/local/bundle


### PR DESCRIPTION
Here is a working docker-compose and Dockerfile that runs spring completely within a container, without requiring the host machine to have ruby installed.  Additionally, I added a volume to hold the bundle cache as an example for others.

```
$ docker-compose ps
            Name                          Command               State    Ports
------------------------------------------------------------------------------
springdockerexample_spring_1   bundle exec spring server        Exit 1
springdockerexample_web_1      bundle exec rails s -p 300 ...   Exit 1

$ time docker-compose run web bin/rake test
Starting springdockerexample_spring_1
Running via Spring preloader in process 15
docker-compose run web bin/rake test  0.33s user 0.08s system 6% cpu 6.803 total

$ docker-compose ps
            Name                          Command               State    Ports
------------------------------------------------------------------------------
springdockerexample_spring_1   bundle exec spring server        Up
springdockerexample_web_1      bundle exec rails s -p 300 ...   Exit 1

$ time docker-compose run web bin/rake test
Running via Spring preloader in process 20
docker-compose run web bin/rake test  0.31s user 0.07s system 15% cpu 2.422 total
```


This took me a _lot_ of trial and error, but it works so I hope this saves someone else some time figuring this out.


If you :+1:, I can also work on updating the README to document this approach.