### PR TITLE
Set umask instead of creating a new user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
 FROM ruby:2.3
 RUN apt-get update -qq && apt-get install -y nodejs
 
-# We need the spring socket file to be readable by the local user on the host,
-# so we need to set up a user account with the same UID. Change this if your
-# UID is not 1000. Obviously there are ways to make this more flexible (build
-# args etc).
-RUN useradd --create-home --user-group --uid 1000 app
-
 RUN mkdir /app && chown -R app:app /app
 WORKDIR /app
-USER app
 
 ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build: .
     volumes:
       - .:/app
-    command: spring server
+    command: sh -c "umask a+rw; exec spring server"
 
     # This ensures that the pid namespace is shared between the host
     # and the container. It's not necessary to be able to run spring


### PR DESCRIPTION
By setting this umask, when the socket file is created, the host container will be able to write to the socket. This prevent many headaches such as having to dynamically the UID.

